### PR TITLE
Allow protocol to be supplied as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ import JsGravatar from 'js-gravatar';
 Call the method
 
 ```js
-JsGravatar({ email: 'user@email.com', size: 10, defaultImage: 'identicon' });
-JsGravatar({ email: 'user@email.com', defaultImage: 'monsterid' });
+const imageURL = JsGravatar({ email: 'user@email.com', size: 10, defaultImage: 'identicon' });
+// or
+const imageURL = JsGravatar({ email: 'user@email.com', defaultImage: 'monsterid' });
+
+const image = document.getElementById('user-image');
+image.src = imageURL;
 ```
 
 ## Parameter Definitions
@@ -62,6 +66,7 @@ JsGravatar({ email: 'user@email.com', defaultImage: 'monsterid' });
 - `md5Hash`: Optional: MD5 hash of the email above. If email is provided, md5hash will be ignored. If neither email nor md5hash is provided, the library will throw en error - string
 - `size`: Optional: The size of the image to be displayed. Should be from 1 to 2048 - number
 - `defaultImage`: What image should be used if email does not have a gravatar. See options below - string
+- `protocol`: What protocol should be used (default is `https:`)
 
 Defaultimage Options - ['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank']
 

--- a/lib/js-gravatar.js
+++ b/lib/js-gravatar.js
@@ -2,7 +2,7 @@ import md5 from 'md5';
 import { Types, Errors } from './types';
 
 export function validateOptions(options) {
-  const { email, md5Hash, size, defaultImage } = options;
+  const { email, md5Hash, size, defaultImage, protocol } = options;
   if (!email && !md5Hash) throw new Error(Errors.MISSING_ARGUMENT_ERROR('email or md5Hash'));
 
   if (size && Number.isNaN(Number(size))) throw new Error(Errors.INVALID_ARGUMENT_TYPE(size, 'number'));
@@ -10,6 +10,8 @@ export function validateOptions(options) {
   if (size > 2048 || size < 1) throw new Error(Errors.IMAGE_SIZE_ERROR);
   
   if (defaultImage && !Types.GRAVATAR_DEFAULTS.includes(defaultImage)) throw new Error(Errors.DEFAULT_IMAGE_ERROR);
+
+  if (protocol && typeof protocol !== 'string') throw new Error(Errors.INVALID_ARGUMENT_TYPE(protocol, 'string'));
 }
 
 function getMd5Hash(options) {
@@ -36,7 +38,7 @@ function jsGravatar(options) {
   const emailHash = getMd5Hash(options);
   const queryString = buildQueryStringFromOptions(options);
 
-  return `${Types.BASE_URL}/${emailHash}${queryString}`;
+  return `${Types.BASE_URL(options.protocol)}/${emailHash}${queryString}`;
 }
 
 export default jsGravatar;

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,12 +1,12 @@
 export const Types = {
-  BASE_URL: (() => {
-    const protocol = window.location.protocol;
+  BASE_URL: (suppliedProtocol) => {
+    const protocol = suppliedProtocol || window.location.protocol;
     const gravatar_url = '//www.gravatar.com/avatar';
     if (protocol !== 'https:') {
       return `http:${gravatar_url}`;
     }
     return `https:${gravatar_url}`;
-  })(),
+  },
   GRAVATAR_DEFAULTS: ['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'],
 };
 

--- a/tests/js_gravatar.test.js
+++ b/tests/js_gravatar.test.js
@@ -36,4 +36,22 @@ describe('JS Gravatar', function () {
       expect(buildQueryStringFromOptions({})).toBe('');
     });
   });
+
+  describe('Correctly generates urls with or without protocol specified', function() {
+    const email = 'test@test.com';
+    const size = 200;
+    const defaultImage = '404';
+
+    it('when no protocol is supplied.', function () {
+      expect(jsGravatar({ email, size, defaultImage })).toBe(`http://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?s=${size}&d=${defaultImage}`);
+    });
+
+    it('when "https:" protocol is supplied.', function () {
+      expect(jsGravatar({ email, size, defaultImage, protocol: 'https:' })).toBe(`https://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?s=${size}&d=${defaultImage}`);
+    });
+
+    it('when "purple:" protocol is supplied.', function () {
+      expect(jsGravatar({ email, size, defaultImage, protocol: 'purple:' })).toBe(`http://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?s=${size}&d=${defaultImage}`);
+    });
+  });
 });


### PR DESCRIPTION
Our use case does not have https as the `window.location`, but we really need to use https for any requests.